### PR TITLE
Api key retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Do not push these files
+# These files don't get pushed to GitHub
 credentials.json
 token.json
 experimentation
@@ -16,3 +16,7 @@ __pycache__
 .DS_Store
 models/*.pth
 intents*.json
+routines
+crash_recovery.p
+bumblebee_token
+logging.*

--- a/bumblebee_wrapper.py
+++ b/bumblebee_wrapper.py
@@ -29,7 +29,8 @@ class BumblebeeWrapper():
         feature_list_name = self.config["Preferences"]["feature_list"]
         self.feature_list = feature_lists.get(feature_list_name,
                                               feature_lists['all'])
-        self.decision_strategy = self.config["Preferences"]["decision_strategy"]
+        self.decision_strategy = self.config[
+            "Preferences"]["decision_strategy"]
         self.wake_word_detector = WakeWordDetector(self.name)
         self.bee = self.__create_bee()
 
@@ -86,12 +87,12 @@ class BumblebeeWrapper():
                 jwt_token = log_user_in()
                 if jwt_token:
                     spinner.start(text="Getting api key from online server.")
-                    response_status_code = get_api_key(jwt_token)
-                    if response_status_code == 200:
+                    if get_api_key(jwt_token) == -1:
+                        spinner.fail(text="Could not download api key.")
+                    else:
                         spinner.succeed(
                             text="Api key successfully downloaded.")
-                    else:
-                        spinner.fail(text="Could not download api key.")
+
             else:
                 spinner.succeed(text="Found Bumblebee token.")
 

--- a/bumblebee_wrapper.py
+++ b/bumblebee_wrapper.py
@@ -7,10 +7,10 @@ import yaml
 from bee import Bee
 from utils.wake_word_detector import WakeWordDetector
 from utils import config_builder
-from helpers import bumblebee_root
+from helpers import bumblebee_root, spinner, \
+    BUMBLEBEE_ONLINE_API_KEY_FILENAME, log_user_in, get_api_key
 from features import feature_lists
 import pyfiglet
-from helpers import spinner
 
 
 class BumblebeeWrapper():
@@ -77,12 +77,29 @@ class BumblebeeWrapper():
             except OSError as exception:
                 spinner.fail()
                 raise OSError(exception)
+            # Check that Bumblebee API key exists.
+            # ----------------------------------------
+            spinner.start("Checking existence of Bumblebee token.")
+            if not os.path.exists(os.path.join(
+                    bumblebee_root, BUMBLEBEE_ONLINE_API_KEY_FILENAME)):
+                spinner.fail(text="Bumblebee token not found.")
+                jwt_token = log_user_in()
+                if jwt_token:
+                    spinner.start(text="Getting api key from online server.")
+                    response_status_code = get_api_key(jwt_token)
+                    if response_status_code == 200:
+                        spinner.succeed(
+                            text="Api key successfully downloaded.")
+                    else:
+                        spinner.fail(text="Could not download api key.")
+            else:
+                spinner.succeed(text="Found Bumblebee token.")
 
     def __create_bee(self):
         '''
         Creates an instance of Bee with name, feature_list and a config file.
         '''
-        # access default mode from config file
+        # access default speech mode from config file
         default_speech_mode = self.config["Utilities"]["default_speech_mode"]
 
         virtual_assistant = Bee(

--- a/features/run_online_tasks.py
+++ b/features/run_online_tasks.py
@@ -1,6 +1,11 @@
 '''Runs features based on tasks retrieved from online.'''
 import requests
+
+
 from features.default import BaseFeature
+
+BUMBLEBEE_ONLINE_GET_COMMANDS_URL = "https://c9o8fm.deta.dev/commands"
+TEST_URL_GET_COMMANDS = "http://127.0.0.1:8000/commands"
 
 
 class Feature(BaseFeature):
@@ -13,15 +18,30 @@ class Feature(BaseFeature):
         self.config = bumblebee_api.get_config()
 
     def action(self, spoken_text, arguments_list: list = []):
+        # Get api key
+        bumblebee_auth_file_path = self.config["Api_keys"]["bumblebee_online"]
+        api_key = ""
+        try:
+            with open(bumblebee_auth_file_path, 'r') as file:
+                api_key = file.read()
+        except IOError:
+            self.bs.respond("Could not access token file.")
         # Get list of tasks from online api.
         try:
-            response = requests.get(url="https://c9o8fm.deta.dev/commands")
-            response_json = response.json()
-            commands_list = response_json["commands"]
-            if len(commands_list) == 0:
-                self.bs.respond("There are no online tasks to run.")
+            headers = {"api_key": api_key}
+            response = requests.get(
+                url=TEST_URL_GET_COMMANDS, headers=headers)
+            if response.status_code == 200:
+                response_json = response.json()
+                commands_list = response_json["commands"]
+                if len(commands_list) == 0:
+                    self.bs.respond("There are no online tasks to run.")
+                    return
+                # Run them using internal api.
+                self.api.run_by_input_list(commands_list)
                 return
-            # Run them using internal api.
-            self.api.run_by_input_list(commands_list)
+            self.bs.respond(
+                f"Could not run online commands due to error code \
+                {response.status_code}.")
         except (requests.ConnectionError):
-            self.bs.respond("No internet connection.")
+            self.bs.respond("Failed to connect to online server.")

--- a/helpers.py
+++ b/helpers.py
@@ -8,10 +8,13 @@ from halo import Halo
 
 
 BUMBLEBEE_ONLINE_API_KEY_FILENAME = 'bumblebee_token'
-BUMBLEBEE_ONLINE_GET_API_KEY_URL = "https://c9o8fm.deta.dev/api-key/new"
+BUMBLEBEE_ONLINE_GET_NEW_API_KEY_URL = "https://c9o8fm.deta.dev/api-key/new"
+BUMBLEBEE_ONLINE_GET_ACTIVE_API_KEY_URL = \
+    "https://c9o8fm.deta.dev/api-key/active"
 BUMBLEBEE_ONLINE_LOGIN_URL = "https://c9o8fm.deta.dev/auth/jwt/login"
-TEST_URL_BUMBLEBEE_LOGIN = "http://127.0.0.1:8000/api-key/new"
-TEST_URL_GET_BUMBLEBEE_API_KEY = "http://127.0.0.1:8000/api-key/new"
+TEST_URL_BUMBLEBEE_LOGIN = "http://127.0.0.1:8000/auth/jwt/login"
+TEST_URL_GET_NEW_BUMBLEBEE_API_KEY = "http://127.0.0.1:8000/api-key/new"
+TEST_URL_GET_ACTIVE_BUMBLEBEE_API_KEY = "http://127.0.0.1:8000/api-key/active"
 
 
 def get_logger(
@@ -100,6 +103,8 @@ Enter the number of the desired option to proceed:
 Note: To log in, you need to have signed up for an account
 on Bumblebee Online here: https://c9o8fm.deta.dev/
 """
+    # TODO: make it so that the user is allowed to retry if they
+    # type in the wrong username/password.
     print(decision_prompt)
     while True:
         decision = input("type here:")
@@ -134,17 +139,50 @@ def get_api_key(jwt: str = None):
     '''
     Gets Bumblebee Online Api Key for a logged in user.
     '''
-    # Use jwt token to ask for api key from Bumblebee Online
-    # api.
+    api_key = None
+    # Try getting already existent active key for user
+    # from bumblebee-online server.
+    api_key = get_active_api_key_for_user(jwt)
+    if not api_key:
+        # If active key is not found for the user, get
+        # a new one from bumblebee-online server.
+        print("Getting new api_key.\n")
+        api_key = get_new_api_key_for_user(jwt)
+    if not api_key:
+        return -1
+    with open(
+            bumblebee_root+BUMBLEBEE_ONLINE_API_KEY_FILENAME, "w") as file:
+        file.write(api_key)
+    return
+
+
+def get_new_api_key_for_user(jwt: str = None):
+    '''
+    Gets an new api key from the bumblebee online server
+    for a logged in user.
+    '''
     headers = {"Authorization": f"Bearer {jwt}"}
-    response = requests.post(TEST_URL_GET_BUMBLEBEE_API_KEY, headers=headers)
-    # Store the api key in a file locally under a specified
-    # BUMBLEBEE_ONLINE_API_KEY filename.
+    response = requests.post(
+        TEST_URL_GET_NEW_BUMBLEBEE_API_KEY, headers=headers)
     if response.status_code == 200:
-        with open(
-                bumblebee_root+BUMBLEBEE_ONLINE_API_KEY_FILENAME, "w") as file:
-            file.write(response.json().get("value"))
-    return response.status_code
+        return response.json().get("value")
+    print(
+        f"{response.status_code} could not get new api key.\n")
+    return
+
+
+def get_active_api_key_for_user(jwt: str = None):
+    '''
+    Gets an existing active api key from the bumblebee online server
+    for a logged in user
+    '''
+    headers = {"Authorization": f"Bearer {jwt}"}
+    response = requests.get(
+        TEST_URL_GET_ACTIVE_BUMBLEBEE_API_KEY, headers=headers)
+    if response.status_code == 200:
+        return response.json().get("value")
+    print(f"{response.status_code} active api_key not found.\n")
+    return
 
 
 spinner = Halo(spinner='dots2')

--- a/requirements.txt
+++ b/requirements.txt
@@ -225,3 +225,4 @@ wrapt==1.12.1
 xmltodict==0.12.0
 zipp==3.4.1
 pyfiglet==0.8.post1
+stdiomask

--- a/utils/config_builder.py
+++ b/utils/config_builder.py
@@ -4,7 +4,7 @@ Any updates to the config.yaml file should be made directly into
 config/config.yaml
 '''
 import yaml
-from helpers import bumblebee_root
+from helpers import BUMBLEBEE_ONLINE_API_KEY_FILENAME, bumblebee_root
 from helpers import python3_path
 
 
@@ -28,6 +28,8 @@ def build_config():
     config["Api_keys"] = {}
     config["Api_keys"]["wolframalpha"] = "YOUR_API_KEY_HERE"
     config["Api_keys"]["gmail"] = "YOUR_PATH_TO_GMAIL_CREDENTIALS_FILE"
+    config["Api_keys"]["bumblebee_online"] = bumblebee_root + \
+        BUMBLEBEE_ONLINE_API_KEY_FILENAME
 
     config["Folders"] = {}
     config["Folders"]["work_study"] = bumblebee_root+"work_study"

--- a/utils/speech.py
+++ b/utils/speech.py
@@ -180,7 +180,7 @@ class BumbleSpeech():
         '''
         Ask the user a question and get a response from them.
         Returns 0 if the answer to the question expresses desire
-        to cease the operation. Otherwise, return the answer to 
+        to cease the operation. Otherwise, return the answer to
         the question.
         '''
         self.respond(question)


### PR DESCRIPTION
This PR implements functionality for bumblebee to retrieve an api key from the `bumblebee-online` server. The `api_key` is used to `run_online_tasks` queued by the task queuer on the server.

# Implementation Summary
* `helpers.py`
  * add function to log user into their online account on the `bumblebee-online` server.
  * add function to retrieve and store `api_key` from the `bumblebee-online` server.
* `bumblebee_wrapper.py`
  * add functionality to check for existence of the `api_key` and give user the option to log in and retrieve the `api_key`, if it does not exist, before bumblebee starts running.
* `features/run_online_tasks.py`
  * modify the `run_online_tasks` feature to send the `GET` request to the server with the `api_key` as an `http` header.
* `config_builder.py`
  * add `api_key` file path to the config builder.    